### PR TITLE
Must not include pure-C header without `extern "C"` in C++

### DIFF
--- a/audio/audioencoder.h
+++ b/audio/audioencoder.h
@@ -20,7 +20,9 @@
 #include <QDebug>
 #include <opus/opus.h>
 #include <codec2/codec2.h>
+extern "C" {
 #include <gsm/gsm.h>
+}
 #include "ext/agc.h"
 
 class AudioEncoder


### PR DESCRIPTION
Fixes unbuildability on most compilers