### PR TITLE
use pkgconfig for qwt includes

### DIFF
--- a/qradiolink.pro
+++ b/qradiolink.pro
@@ -161,7 +161,7 @@ LIBS += -lrt  # need to include on some distros
 unix:!symbian: LIBS += -lprotobuf -lopus -lpulse-simple -lpulse -lcodec2 -lgsm -lasound -ljpeg -lconfig++ -lspeexdsp
                     #-lFestival -lestbase -leststring -lestools
 #INCLUDEPATH += /usr/include/speech_tools
-INCLUDEPATH += /usr/include/qwt-qt4
-INCLUDEPATH += /usr/include/qwt
+CONFIG += link_pkgconfig
+PKGCONFIG += Qt5Qwt
 
 RESOURCES += resources.qrc

--- a/qradiolink.pro
+++ b/qradiolink.pro
@@ -161,8 +161,7 @@ LIBS += -lrt  # need to include on some distros
 unix:!symbian: LIBS += -lprotobuf -lopus -lpulse-simple -lpulse -lcodec2 -lgsm -lasound -ljpeg -lconfig++ -lspeexdsp
                     #-lFestival -lestbase -leststring -lestools
 #INCLUDEPATH += /usr/include/speech_tools
-QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig
-PKGCONFIG += Qt4Qwt Qt5Qwt
+PKGCONFIG += Qt5Qwt
 
 RESOURCES += resources.qrc

--- a/qradiolink.pro
+++ b/qradiolink.pro
@@ -161,7 +161,8 @@ LIBS += -lrt  # need to include on some distros
 unix:!symbian: LIBS += -lprotobuf -lopus -lpulse-simple -lpulse -lcodec2 -lgsm -lasound -ljpeg -lconfig++ -lspeexdsp
                     #-lFestival -lestbase -leststring -lestools
 #INCLUDEPATH += /usr/include/speech_tools
+QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig
-PKGCONFIG += Qt5Qwt
+PKGCONFIG += Qt4Qwt Qt5Qwt
 
 RESOURCES += resources.qrc


### PR DESCRIPTION
qt4 is dead and removed from modern distros, safe to remove from git
version.
use pkgconfig to find includes et al for qwt
fixes issue #26 